### PR TITLE
Don't empty dbcache on prune flushes: >30% faster IBD

### DIFF
--- a/src/txdb.h
+++ b/src/txdb.h
@@ -75,7 +75,7 @@ public:
     bool HaveCoin(const COutPoint &outpoint) const override;
     uint256 GetBestBlock() const override;
     std::vector<uint256> GetHeadBlocks() const override;
-    bool BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlock, bool erase = true) override;
+    bool BatchWrite(CCoinsCacheEntry *entries, const uint256 &hashBlock, bool erase = true) override;
     std::unique_ptr<CCoinsViewCursor> Cursor() const override;
 
     //! Whether an unsupported database format is used.

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2543,8 +2543,10 @@ bool Chainstate::FlushStateToDisk(
                 return FatalError(m_chainman.GetNotifications(), state, "Disk space is too low!", _("Disk space is too low!"));
             }
             // Flush the chainstate (which may refer to block index entries).
-            if (!CoinsTip().Flush())
+            const auto empty_cache{(mode == FlushStateMode::ALWAYS) || fCacheLarge || fCacheCritical || fPeriodicFlush};
+            if (empty_cache ? !CoinsTip().Flush() : !CoinsTip().Sync()) {
                 return FatalError(m_chainman.GetNotifications(), state, "Failed to write to coin database");
+            }
             m_last_flush = nNow;
             full_flush_completed = true;
             TRACE5(utxocache, flush,


### PR DESCRIPTION
Since https://github.com/bitcoin/bitcoin/pull/17487 we no longer need to clear the coins cache when syncing to disk. A warm coins cache significantly speeds up block connection, and only needs to be fully flushed when nearing the `dbcache` limit.

For frequent pruning flushes there's no need to empty the cache and kill connect block speed. However, simply using `Sync` in place of `Flush` actually slows down a pruned full IBD with a high `dbcache` value. This is because as the cache grows, sync takes longer since every coin in the cache is iterated to check if it's dirty. For frequent prune flushes and a large cache this starts to really slow IBD down, and just emptying the cache on every prune becomes faster.

To fix this, we can add two pointers to each cache entry and construct a doubly linked list of dirty entries. We can then only iterate through all dirty entries on each `Sync`, and simply clear the pointers. A third pointer to the `COutPoint` is also needed since the linked list iterator won't have the corresponding outpoint anymore.

With this approach a full IBD with `dbcache=16384` and `prune=550` was 34% faster than master. For default `dbcache=450` speedup was 10%. All benchmarks were run with `stopatheight=800000`.

|  | prune | dbcache | time | max RSS | speedup |
|-----------:|----------:|------------:|--------:|-------------:|--------------:|
| master | 550 | 16384 | 8:52:57 | 2,417,464k |-|
| branch | 550 | 16384 | 5:51:03 | 17,109,712k | 34% |
| branch | 550 | 450 | 7:56:31 | 2,856,416k | 10.5% |
| master | 0 | 16384 | 4:51:53 | 14,726,408k | - |
| branch | 0 | 16384 | 4:43:13 | 17,256,760k | 2.7% |
| master | 0 | 450 | 7:08:07 | 3,005,892k | - |
| branch | 0 | 450 | 7:08:38 | 2,986,396k |-|

While the 3 pointers add memory to each cache entry, it did not slow down IBD. For non-pruned IBD results were similar for this branch and master. A non-pruned IBD with full `dbcache` to tip ended up using 15% more memory, but it was also 2.7% faster somehow. For smaller `dbcache` values the `dbcache` limit is respected so does not consume more memory, and the potentially more frequent flushes were not significant enough to cause any slowdown.

Inspired by [this comment](https://github.com/bitcoin/bitcoin/pull/15265#issuecomment-457720636).

Fixes https://github.com/bitcoin/bitcoin/issues/11315.